### PR TITLE
Fixes #34: ruff fails to run (old version installed with requirements.txt)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ name: Docker Image CI
 on:
   push:
     branches:
-      - 34-ruff-fails-version-installed-with-requirementstxt
+      - main
   pull_request:
   # Absence of the branches property under pull_request means it will apply to all branches
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ name: Docker Image CI
 on:
   push:
     branches:
-      - main
+      - 34-ruff-fails-version-installed-with-requirementstxt
   pull_request:
   # Absence of the branches property under pull_request means it will apply to all branches
 
@@ -19,7 +19,7 @@ jobs:
     uses: ai-cfia/github-workflows/.github/workflows/workflow-build-container.yml@main
     with:
       container-name: ${{ github.event.repository.name }}
-      tag: ${{ github.sha }}    
+      tag: ${{ github.sha }}
     secrets: inherit
 
   deploy:
@@ -30,4 +30,3 @@ jobs:
       container-name: ${{ github.event.repository.name }}
       tag: ${{ github.sha }}
     secrets: inherit
-  

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ python-dotenv==1.0.0
 pytz==2023.3
 regex==2023.6.3
 requests==2.31.0
-ruff==0.0.280
 six==1.16.0
 tiktoken==0.4.0
 tqdm==4.65.0


### PR DESCRIPTION
#34 
Removed ruff from requirements.txt it was either that or change the workflow to not specify a version of ruff but it's better to have everything standardized

tested locally and [here](https://github.com/ai-cfia/louis-db/actions/runs/6748008273/job/18345414501)